### PR TITLE
[REF] base_import_match: Small rst fixes in readme file

### DIFF
--- a/base_import_match/README.rst
+++ b/base_import_match/README.rst
@@ -23,20 +23,26 @@ After installing this module, the import logic will be changed to:
 
 - If you import the XMLID of a record, make an **update**.
 - If you do not:
+
   - If there are import match rules for the model you are importing:
-      - Discard the rules that require fields you are not importing.
-      - Traverse the remaining rules one by one in order to find a match in
-        the database.
-          - Skip the rule if it requires a special condition that is not
-            satisfied.
-          - If one match is found:
-            - Stop traversing the rest of valid rules.
-            - **Update** that record.
-          - If zero or multiple matches are found:
-            - Continue with the next rule.
-          - If all rules are exhausted and no single match is found:
-            - **Create** a new record.
+
+    - Discard the rules that require fields you are not importing.
+    - Traverse the remaining rules one by one in order to find a match in the database.
+
+        - Skip the rule if it requires a special condition that is not
+          satisfied.
+        - If one match is found:
+
+          - Stop traversing the rest of valid rules.
+          - **Update** that record.
+        - If zero or multiple matches are found:
+
+          - Continue with the next rule.
+        - If all rules are exhausted and no single match is found:
+
+          - **Create** a new record.
   - If there are no match rules for your model:
+
     - **Create** a new record.
 
 By default 2 rules are installed for production instances:
@@ -59,6 +65,7 @@ To configure this module, you need to:
 #. If the rule must be used only for certain imported values, check
    *Conditional* and enter the **exact string** that is going to be imported
    in *Imported value*.
+
    #. Keep in mind that the match here is evaluated as a case sensitive
       **text string** always. If you enter e.g. ``True``, it will match that
       string, but will not match ``1`` or ``true``.


### PR DESCRIPTION
I used http://rst.ninjs.org/ to fix [current errors](https://travis-ci.org/OCA/server-tools/jobs/132766029#L423-L427) of `base_import_match/README.rst` file.

And applying the following patch:
```patch
diff --git base_import_match/README.rst base_import_match/README.rst
index f1c6577..52609b4 100644
--- base_import_match/README.rst
+++ base_import_match/README.rst
@@ -23,20 +23,26 @@ After installing this module, the import logic will be changed to:
 
 - If you import the XMLID of a record, make an **update**.
 - If you do not:
+
   - If there are import match rules for the model you are importing:
-      - Discard the rules that require fields you are not importing.
-      - Traverse the remaining rules one by one in order to find a match in
-        the database.
-          - Skip the rule if it requires a special condition that is not
-            satisfied.
-          - If one match is found:
-            - Stop traversing the rest of valid rules.
-            - **Update** that record.
-          - If zero or multiple matches are found:
-            - Continue with the next rule.
-          - If all rules are exhausted and no single match is found:
-            - **Create** a new record.
+
+    - Discard the rules that require fields you are not importing.
+    - Traverse the remaining rules one by one in order to find a match in the database.
+
+        - Skip the rule if it requires a special condition that is not
+          satisfied.
+        - If one match is found:
+
+          - Stop traversing the rest of valid rules.
+          - **Update** that record.
+        - If zero or multiple matches are found:
+
+          - Continue with the next rule.
+        - If all rules are exhausted and no single match is found:
+
+          - **Create** a new record.
   - If there are no match rules for your model:
+
     - **Create** a new record.
 
 By default 2 rules are installed for production instances:
@@ -59,6 +65,7 @@ To configure this module, you need to:
 #. If the rule must be used only for certain imported values, check
    *Conditional* and enter the **exact string** that is going to be imported
    in *Imported value*.
+
    #. Keep in mind that the match here is evaluated as a case sensitive
       **text string** always. If you enter e.g. ``True``, it will match that
       string, but will not match ``1`` or ``true``.

```

Now don't show rst errors:
<img width="1248" alt="screen shot 2016-05-25 at 10 40 00 am" src="https://cloud.githubusercontent.com/assets/6644187/15546318/0f175bd2-2265-11e6-9726-a114f64e8992.png">

Applied with:
`patch -p0 < moy.patch`